### PR TITLE
MDOCS-2491

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19236,7 +19236,7 @@
       }
     },
     "packages/quill": {
-      "version": "2.0.3",
+      "version": "2.0.4-beta.13",
       "license": "BSD-3-Clause",
       "dependencies": {
         "eventemitter3": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4283,18 +4283,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.44.1"
+        "playwright": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -10253,7 +10254,8 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -15173,33 +15175,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -19236,7 +19240,7 @@
       }
     },
     "packages/quill": {
-      "version": "2.0.4-beta.13",
+      "version": "2.0.4-beta.15",
       "license": "BSD-3-Clause",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -19249,7 +19253,7 @@
         "@babel/core": "^7.24.0",
         "@babel/preset-env": "^7.24.0",
         "@babel/preset-typescript": "^7.23.3",
-        "@playwright/test": "1.44.1",
+        "@playwright/test": "1.50.0",
         "@types/highlight.js": "^9.12.4",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.10.0",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-typescript": "^7.23.3",
-    "@playwright/test": "1.44.1",
+    "@playwright/test": "1.50.0",
     "@types/highlight.js": "^9.12.4",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.10.0",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.0.4-beta.13",
+  "version": "2.0.4-beta.15",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",

--- a/packages/quill/src/modules/input.ts
+++ b/packages/quill/src/modules/input.ts
@@ -2,7 +2,7 @@ import Delta from 'quill-delta';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type { Range } from '../core/selection.js';
-import { CHECK_KOREAN, deleteRange, ZERO_SPACE } from './keyboard.js';
+import { deleteRange, ZERO_SPACE } from './keyboard.js';
 
 const INSERT_TYPES = ['insertText', 'insertReplacementText'];
 
@@ -57,10 +57,9 @@ class Input extends Module {
         // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
         range?.index!,
       );
-      const text = getPlainTextFromInputEvent(event);
-      // In the case that we are typing Korean at the beginning of a new line, sometimes
+      // In the case that we are typing Korean/Japanese (Romaji) at the beginning of a new line, sometimes
       // jamo do not compose together as expected but placing a ZWSP immediately before fixes this problem
-      if (range && offset === 0 && text && CHECK_KOREAN.test(text)) {
+      if (range && offset === 0 && this.quill.composition.isComposing) {
         this.quill.insertText(range.index, ZERO_SPACE, 'user');
       }
 

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -344,7 +344,6 @@ class Keyboard extends Module<KeyboardOptions> {
   }
 
   handleDelete(range: Range, context: Context) {
-    // const text = context.suffix;
     // Check for astral symbols
     const length = /^[\uD800-\uDBFF][\uDC00-\uDFFF]/.test(context.suffix)
       ? 2

--- a/packages/quill/test/unit/core/composition.spec.ts
+++ b/packages/quill/test/unit/core/composition.spec.ts
@@ -34,12 +34,13 @@ describe('Composition', () => {
     const scroll = new Scroll(createRegistry(), document.createElement('div'), {
       emitter,
     });
-    new Composition(scroll, emitter);
+    const composition = new Composition(scroll, emitter);
 
     vitest.spyOn(emitter, 'emit');
 
     const event = new CompositionEvent('compositionstart');
     scroll.domNode.dispatchEvent(event);
+    composition.isComposing = false;
     const updateEvent = new CompositionEvent('compositionupdate');
     scroll.domNode.dispatchEvent(updateEvent);
     expect(emitter.emit).toHaveBeenCalledWith(

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1257,17 +1257,17 @@ describe('Editor', () => {
           0,
           11,
         ),
-      ).toEqual('<strong>123&nbsp;</strong>123<em>&nbsp;123</em>');
+      ).toEqual('<strong>123 </strong>123<em> 123</em>');
 
       expect(createEditor(new Delta().insert('1   2\n')).getHTML(0, 5)).toEqual(
-        '1&nbsp;&nbsp;&nbsp;2',
+        '1   2',
       );
 
       expect(
         createEditor(
           new Delta().insert('  123', { bold: true }).insert('\n'),
         ).getHTML(0, 5),
-      ).toEqual('<strong>&nbsp;&nbsp;123</strong>');
+      ).toEqual('<strong>  123</strong>');
     });
 
     test('mixed list', () => {

--- a/packages/quill/tsconfig.json
+++ b/packages/quill/tsconfig.json
@@ -15,7 +15,8 @@
     "moduleResolution": "bundler",
     "strictNullChecks": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
- Don't use a regex for inserting a ZWSP in `beforeinput`. Instead just check `quill.composition.isComposing` because this also works for Japanese (Romaji)
- Fix some unit tests