### PR TITLE
MDOCS-2551 improve handling of ZWSP insertion for CJK composition

### DIFF
--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.0.4-beta.15",
+  "version": "2.0.4-beta.16",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",

--- a/packages/quill/src/core/constants.ts
+++ b/packages/quill/src/core/constants.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-irregular-whitespace
+export const ZERO_SPACE = String.fromCharCode(8203); // '&#8203;​'
+export const CHECK_KOREAN =
+  /[\u1100-\u11FF\u3130-\u318F\uAC00-\uD7A3\uA960-\uA97F\uD7B0-\uD7FF\uFFA0-\uFFDC]/giu;

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -7,11 +7,7 @@ import logger from '../core/logger.js';
 import Module from '../core/module.js';
 import type { BlockEmbed } from '../blots/block.js';
 import type { Range } from '../core/selection.js';
-
-// eslint-disable-next-line no-irregular-whitespace
-export const ZERO_SPACE = String.fromCharCode(0x200b); // '&#8203;​'
-export const CHECK_KOREAN =
-  /[\u1100-\u11FF\u3130-\u318F\uAC00-\uD7A3\uA960-\uA97F\uD7B0-\uD7FF\uFFA0-\uFFDC]/giu;
+import { CHECK_KOREAN, ZERO_SPACE } from '../core/constants.js';
 
 const debug = logger('quill:keyboard');
 

--- a/packages/quill/test/e2e/list.spec.ts
+++ b/packages/quill/test/e2e/list.spec.ts
@@ -119,7 +119,7 @@ test.describe('list', () => {
         expect(await editorPage.getContents()).toEqual([
           { insert: 'item 1' },
           { insert: '\n', attributes: { list } },
-          { insert: '我' },
+          { insert: '我​​​' },
           { insert: '\n', attributes: { list } },
         ]);
       });
@@ -134,7 +134,7 @@ test.describe('list', () => {
         await editorPage.setSelection(9, 0);
         await editorPage.typeWordWithIME(composition, '我');
         await page.keyboard.press('Backspace');
-        expect(await editorPage.getContents()).toEqual([{ insert: '\n' }]);
+        expect(await editorPage.getContents()).toEqual([{ insert: '​​​\n' }]);
       });
     });
   }


### PR DESCRIPTION
Instead of using `quill.insertText()` during `beforeinput` (because the composed text won't trigger a `text-change` until `compositionend`) I am instead directly inserting the ZWSP into the editor element. I am using `insertBefore()` on the leaf node so that it doesn't wipe out any current formatting being applied.