### PR TITLE
inserts at the end of a block should still try to insert within the last child

### DIFF
--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -64,10 +64,28 @@ class Block extends BlockBlot {
       const softLines = text.split(softBreakRegex);
       let i = index;
       softLines.forEach((str) => {
-        if (str === SOFT_BREAK_CHARACTER) {
-          super.insertAt(i, SoftBreak.blotName, SOFT_BREAK_CHARACTER);
+        if (i < this.length() - 1 || this.children.tail == null) {
+          const insertIndex = Math.min(i, this.length() - 1);
+          if (str === SOFT_BREAK_CHARACTER) {
+            super.insertAt(
+              insertIndex,
+              SoftBreak.blotName,
+              SOFT_BREAK_CHARACTER,
+            );
+          } else {
+            super.insertAt(insertIndex, str);
+          }
         } else {
-          super.insertAt(Math.min(i, this.length() - 1), str);
+          const insertIndex = this.children.tail.length();
+          if (str === SOFT_BREAK_CHARACTER) {
+            this.children.tail.insertAt(
+              insertIndex,
+              SoftBreak.blotName,
+              SOFT_BREAK_CHARACTER,
+            );
+          } else {
+            this.children.tail.insertAt(insertIndex, str);
+          }
         }
         i += str.length;
       });

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -195,11 +195,11 @@ describe('Editor', () => {
       editor.insertText(4, SOFT_BREAK_CHARACTER);
       expect(editor.getDelta()).toEqual(
         new Delta()
-          .insert('0123', { bold: true })
-          .insert(`${SOFT_BREAK_CHARACTER}\n`),
+          .insert(`0123${SOFT_BREAK_CHARACTER}`, { bold: true })
+          .insert('\n'),
       );
       expect(editor.scroll.domNode).toEqualHTML(`
-        <p><strong>0123</strong><br class="soft-break"><br></p>`);
+        <p><strong>0123<br class="soft-break"></strong><br></p>`);
     });
 
     test('multiline text', () => {
@@ -244,6 +244,20 @@ describe('Editor', () => {
       editor.insertText(2, '23', { bold: false, strike: false });
       expect(editor.getDelta()).toEqual(
         new Delta().insert('01', { strike: true }).insert('23\n'),
+      );
+    });
+
+    test('formatted text at the end of a block that ends with other format', () => {
+      const editor = createEditor('<p><strong>01</strong></p>');
+      editor.insertText(2, 'example', { link: 'http://example.com' });
+      expect(editor.getDelta()).toEqual(
+        new Delta()
+          .insert('01', { bold: true })
+          .insert('example', { link: 'http://example.com', bold: true })
+          .insert('\n'),
+      );
+      expect(editor.scroll.domNode).toEqualHTML(
+        '<p><strong>01<a rel="noopener noreferrer" target="_blank" href="http://example.com">example</a></strong></p>',
       );
     });
   });


### PR DESCRIPTION
this is a fix for a regression introduced by the logic added to the block blot for handling inserts of soft break characters.