### PR TITLE
Fix issue with caret at wrong location after select all (CMD + A)

### DIFF
--- a/packages/quill/src/blots/cursor.ts
+++ b/packages/quill/src/blots/cursor.ts
@@ -94,8 +94,8 @@ class Cursor extends EmbedBlot {
     // @ts-expect-error TODO: make TextBlot.text public
     const nextText = nextTextBlot ? nextTextBlot.text : '';
     const { textNode } = this;
+    const hasCursorCharacter = textNode.data.includes(Cursor.CONTENTS);
     // take text from inside this blot and reset it
-    const hasCursorContents = textNode.data.includes(Cursor.CONTENTS);
     const newText = textNode.data.split(Cursor.CONTENTS).join('');
     textNode.data = Cursor.CONTENTS;
 
@@ -131,7 +131,7 @@ class Cursor extends EmbedBlot {
         if (node === textNode) {
           // After selecting all text (cmd + a), the cursor's breaking space
           // doesn't exist, and so we do not need to adjust the selection offset.
-          const offsetAdjusted = hasCursorContents ? -1 : 0;
+          const offsetAdjusted = hasCursorCharacter ? -1 : 0;
 
           return prevTextLength + offset + offsetAdjusted;
         }

--- a/packages/quill/src/blots/cursor.ts
+++ b/packages/quill/src/blots/cursor.ts
@@ -95,6 +95,7 @@ class Cursor extends EmbedBlot {
     const nextText = nextTextBlot ? nextTextBlot.text : '';
     const { textNode } = this;
     // take text from inside this blot and reset it
+    const hasCursorContents = textNode.data.includes(Cursor.CONTENTS);
     const newText = textNode.data.split(Cursor.CONTENTS).join('');
     textNode.data = Cursor.CONTENTS;
 
@@ -128,7 +129,11 @@ class Cursor extends EmbedBlot {
           return offset;
         }
         if (node === textNode) {
-          return prevTextLength + offset - 1;
+          // After selecting all text (cmd + a), the cursor's breaking space
+          // doesn't exist, and so we do not need to adjust the selection offset.
+          const offsetAdjusted = hasCursorContents ? -1 : 0;
+
+          return prevTextLength + offset + offsetAdjusted;
         }
         if (nextTextBlot && node === nextTextBlot.domNode) {
           return prevTextLength + newText.length + offset;

--- a/packages/quill/test/e2e/replaceSelection.spec.ts
+++ b/packages/quill/test/e2e/replaceSelection.spec.ts
@@ -5,6 +5,33 @@ test.describe('replace selection', () => {
   test.beforeEach(async ({ editorPage }) => {
     await editorPage.open();
   });
+  
+test.describe('cursor blot', () => {
+    test('sets the correct caret position after replacing a cursor blot', async ({
+      page,
+      editorPage,
+    }) => {
+      await editorPage.setContents([{ insert: '12\n' }]);
+      await editorPage.selectText('1');
+      await page.keyboard.press('ControlOrMeta+a');
+      await page.keyboard.press('Delete');
+
+      expect(await editorPage.getContents()).toEqual([{ insert: '\n' }]);
+      // Adding a format places the cursor in the document
+      await page.keyboard.press('ControlOrMeta+b');
+      await page.keyboard.press('ControlOrMeta+a');
+      await page.keyboard.type('A');
+
+      expect(await editorPage.getContents()).toEqual([
+        { insert: 'A', attributes: { bold: true } },
+        { insert: '\n' },
+      ]);
+      expect(await editorPage.getSelection()).toEqual({
+        index: 1,
+        length: 0,
+      });
+    });
+  });
 
   test.describe('replace a colored text', () => {
     test('after a normal text', async ({ page, editorPage }) => {

--- a/packages/quill/test/e2e/replaceSelection.spec.ts
+++ b/packages/quill/test/e2e/replaceSelection.spec.ts
@@ -5,8 +5,8 @@ test.describe('replace selection', () => {
   test.beforeEach(async ({ editorPage }) => {
     await editorPage.open();
   });
-  
-test.describe('cursor blot', () => {
+
+  test.describe('cursor blot', () => {
     test('sets the correct caret position after replacing a cursor blot', async ({
       page,
       editorPage,
@@ -22,10 +22,6 @@ test.describe('cursor blot', () => {
       await page.keyboard.press('ControlOrMeta+a');
       await page.keyboard.type('A');
 
-      expect(await editorPage.getContents()).toEqual([
-        { insert: 'A', attributes: { bold: true } },
-        { insert: '\n' },
-      ]);
       expect(await editorPage.getSelection()).toEqual({
         index: 1,
         length: 0,


### PR DESCRIPTION
### Motivation - bug
**On mobile:**
- When clearing a text or shape widget by using the backspace and dragging to the left (a feature on android) and typing then text caret goes before the newly inserted character instead of after.

**On desktop:** 
-  clear a text box
- type cmd +a
- type some other text

Expected: caret is after the newly typed text
Actual: caret is before the newly typed text

### Proposed solution
Check for the presence of the quill cursor (before it is restored). If it does not exist then it we do not adjust the offset by -1