### PR TITLE
MDOCS-2916 Make composition handling synchronous to prevent text loss

### DIFF
--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.0.4-beta.20",
+  "version": "2.0.4-beta.26",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",

--- a/packages/quill/src/core/composition.ts
+++ b/packages/quill/src/core/composition.ts
@@ -26,7 +26,10 @@ class Composition {
 
     this.scroll.domNode.addEventListener('compositionend', (event) => {
       if (this.isComposing) {
-        // Only use queueMicrotask for Safari/WebKit browsers where the bug exists
+        // Only use queueMicrotask for WebKit browsers where the bug exists.
+        // When we call blur() to trigger "compositionend" before destroying the editor, the async handling means the
+        // Delta updates after we've already called getHTML(). Synchronous handling ensures the Delta updates
+        // immediately within the same tick, capturing all text.
         if (isWebkit()) {
           // HACK: There is a bug in the safari browser in mobile devices and when we finish typing
           // composition symbol MutationObserver dispatches part of events after firing compositionend event

--- a/packages/quill/src/core/composition.ts
+++ b/packages/quill/src/core/composition.ts
@@ -1,7 +1,7 @@
 import Embed from '../blots/embed.js';
 import type Scroll from '../blots/scroll.js';
 import Emitter from './emitter.js';
-import { isSafariOrWebKit } from './utils/browser.js';
+import { isWebkit } from './utils/browser.js';
 
 class Composition {
   isComposing = false;
@@ -27,7 +27,7 @@ class Composition {
     this.scroll.domNode.addEventListener('compositionend', (event) => {
       if (this.isComposing) {
         // Only use queueMicrotask for Safari/WebKit browsers where the bug exists
-        if (isSafariOrWebKit()) {
+        if (isWebkit()) {
           // HACK: There is a bug in the safari browser in mobile devices and when we finish typing
           // composition symbol MutationObserver dispatches part of events after firing compositionend event
           // In normal behaviour MutationObserver dispatches all event before firing compositionend event

--- a/packages/quill/src/core/composition.ts
+++ b/packages/quill/src/core/composition.ts
@@ -1,6 +1,7 @@
 import Embed from '../blots/embed.js';
 import type Scroll from '../blots/scroll.js';
 import Emitter from './emitter.js';
+import { isSafariOrWebKit } from './utils/browser.js';
 
 class Composition {
   isComposing = false;
@@ -25,16 +26,23 @@ class Composition {
 
     this.scroll.domNode.addEventListener('compositionend', (event) => {
       if (this.isComposing) {
-        // HACK: There is a bug in the safari browser in mobile devices and when we finish typing
-        // composition symbol MutationObserver dispatches part of events after firing compositionend event
-        // In normal behaviour MutationObserver dispatches all event before firing compositionend event
-        // https://bugs.webkit.org/show_bug.cgi?id=238013
-        // Webkit makes DOM changes after compositionend, so we use microtask to
-        // ensure the order.
-        // https://bugs.webkit.org/show_bug.cgi?id=31902
-        queueMicrotask(() => {
-          this.handleCompositionEnd(event);
-        });
+        // Only use queueMicrotask for Safari/WebKit browsers where the bug exists
+        if (isSafariOrWebKit()) {
+          // HACK: There is a bug in the safari browser in mobile devices and when we finish typing
+          // composition symbol MutationObserver dispatches part of events after firing compositionend event
+          // In normal behaviour MutationObserver dispatches all event before firing compositionend event
+          // https://bugs.webkit.org/show_bug.cgi?id=238013
+          // Webkit makes DOM changes after compositionend, so we use microtask to
+          // ensure the order.
+          // https://bugs.webkit.org/show_bug.cgi?id=31902
+          queueMicrotask(() => {
+            this.handleCompositionEnd(event);
+          });
+          return;
+        }
+
+        // For all other browsers, handle synchronously
+        this.handleCompositionEnd(event);
       }
     });
   }

--- a/packages/quill/src/core/utils/browser.ts
+++ b/packages/quill/src/core/utils/browser.ts
@@ -38,4 +38,3 @@ export function isSafariOrWebKit(): boolean {
   isSafariOrWebKitCache = isSafari || isIOS;
   return isSafariOrWebKitCache;
 }
-

--- a/packages/quill/src/core/utils/browser.ts
+++ b/packages/quill/src/core/utils/browser.ts
@@ -7,25 +7,24 @@
  * @internal
  */
 export function _clearBrowserDetectionCache(): void {
-  isSafariOrWebKitCache = undefined;
+  isWebkitCache = undefined;
 }
 
 // Cache results to avoid repeated calculations during typing
-let isSafariOrWebKitCache: boolean | undefined;
+let isWebkitCache: boolean | undefined;
 
 /**
- * Detects if the browser is Safari or WebKit-based on iOS/iPadOS
- * This is used to handle Safari-specific bugs with composition events
+ * Detects if the browser is WebKit-based (e.g., Safari, iOS browsers).
  */
-export function isSafariOrWebKit(): boolean {
+export function isWebkit(): boolean {
   // Return cached result if available
-  if (isSafariOrWebKitCache !== undefined) {
-    return isSafariOrWebKitCache;
+  if (isWebkitCache !== undefined) {
+    return isWebkitCache;
   }
 
   const userAgent = navigator.userAgent.toLowerCase();
 
-  // Check for Safari on macOS (not Chrome)
+  // Check for Safari on macOS
   const isSafari =
     userAgent.includes('safari') && !userAgent.includes('chrome');
 
@@ -35,6 +34,6 @@ export function isSafariOrWebKit(): boolean {
     (userAgent.includes('mac') && navigator.maxTouchPoints > 1);
 
   // Cache and return result
-  isSafariOrWebKitCache = isSafari || isIOS;
-  return isSafariOrWebKitCache;
+  isWebkitCache = isSafari || isIOS;
+  return isWebkitCache;
 }

--- a/packages/quill/src/core/utils/browser.ts
+++ b/packages/quill/src/core/utils/browser.ts
@@ -1,0 +1,41 @@
+/**
+ * Browser detection utilities for Quill
+ */
+
+/**
+ * Clear the browser detection cache - for testing purposes only
+ * @internal
+ */
+export function _clearBrowserDetectionCache(): void {
+  isSafariOrWebKitCache = undefined;
+}
+
+// Cache results to avoid repeated calculations during typing
+let isSafariOrWebKitCache: boolean | undefined;
+
+/**
+ * Detects if the browser is Safari or WebKit-based on iOS/iPadOS
+ * This is used to handle Safari-specific bugs with composition events
+ */
+export function isSafariOrWebKit(): boolean {
+  // Return cached result if available
+  if (isSafariOrWebKitCache !== undefined) {
+    return isSafariOrWebKitCache;
+  }
+
+  const userAgent = navigator.userAgent.toLowerCase();
+
+  // Check for Safari on macOS (not Chrome)
+  const isSafari =
+    userAgent.includes('safari') && !userAgent.includes('chrome');
+
+  // Check for iOS/iPadOS (all browsers on iOS use WebKit)
+  const isIOS =
+    /iphone|ipad|ipod/.test(userAgent) ||
+    (userAgent.includes('mac') && navigator.maxTouchPoints > 1);
+
+  // Cache and return result
+  isSafariOrWebKitCache = isSafari || isIOS;
+  return isSafariOrWebKitCache;
+}
+

--- a/packages/quill/test/unit/core/utils/browser.spec.ts
+++ b/packages/quill/test/unit/core/utils/browser.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  isSafariOrWebKit,
+  isWebkit,
   _clearBrowserDetectionCache,
 } from '../../../../src/core/utils/browser.js';
 
@@ -76,7 +76,7 @@ describe('Browser Detection', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
         'Apple Computer, Inc.',
       );
-      expect(isSafariOrWebKit()).toBe(true);
+      expect(isWebkit()).toBe(true);
     });
 
     it('detects Safari on iOS', () => {
@@ -85,7 +85,7 @@ describe('Browser Detection', () => {
         'Apple Computer, Inc.',
         'iPhone',
       );
-      expect(isSafariOrWebKit()).toBe(true);
+      expect(isWebkit()).toBe(true);
     });
 
     it('detects Safari on iPad', () => {
@@ -94,7 +94,7 @@ describe('Browser Detection', () => {
         'Apple Computer, Inc.',
         'iPad',
       );
-      expect(isSafariOrWebKit()).toBe(true);
+      expect(isWebkit()).toBe(true);
     });
 
     it('detects iPad with desktop mode (iPadOS 13+)', () => {
@@ -104,7 +104,7 @@ describe('Browser Detection', () => {
         'MacIntel',
         5, // iPad has multiple touch points
       );
-      expect(isSafariOrWebKit()).toBe(true);
+      expect(isWebkit()).toBe(true);
     });
 
     it('does not detect Chrome on macOS', () => {
@@ -112,7 +112,7 @@ describe('Browser Detection', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
         'Google Inc.',
       );
-      expect(isSafariOrWebKit()).toBe(false);
+      expect(isWebkit()).toBe(false);
     });
 
     it('does not detect Firefox', () => {
@@ -120,7 +120,7 @@ describe('Browser Detection', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) Gecko/20100101 Firefox/119.0',
         '',
       );
-      expect(isSafariOrWebKit()).toBe(false);
+      expect(isWebkit()).toBe(false);
     });
 
     it('does not detect Chrome on Android', () => {
@@ -129,7 +129,7 @@ describe('Browser Detection', () => {
         'Google Inc.',
         'Linux armv8l',
       );
-      expect(isSafariOrWebKit()).toBe(false);
+      expect(isWebkit()).toBe(false);
     });
 
     it('returns consistent results when called multiple times', () => {
@@ -137,21 +137,21 @@ describe('Browser Detection', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
         'Apple Computer, Inc.',
       );
-      const firstCall = isSafariOrWebKit();
+      const firstCall = isWebkit();
       mockNavigator(
         'different user agent',
         'different vendor',
         'different platform',
         1,
       );
-      const secondCall = isSafariOrWebKit();
+      const secondCall = isWebkit();
       mockNavigator(
         'another user agent',
         'another vendor',
         'another platform',
         2,
       );
-      const thirdCall = isSafariOrWebKit();
+      const thirdCall = isWebkit();
 
       expect(firstCall).toBe(true);
       expect(secondCall).toBe(true);

--- a/packages/quill/test/unit/core/utils/browser.spec.ts
+++ b/packages/quill/test/unit/core/utils/browser.spec.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { isSafariOrWebKit, _clearBrowserDetectionCache } from '../../../../src/core/utils/browser.js';
+import {
+  isSafariOrWebKit,
+  _clearBrowserDetectionCache,
+} from '../../../../src/core/utils/browser.js';
 
 describe('Browser Detection', () => {
   let originalUserAgent: PropertyDescriptor | undefined;
@@ -10,7 +13,7 @@ describe('Browser Detection', () => {
   beforeEach(() => {
     // Clear the cache before each test
     _clearBrowserDetectionCache();
-    
+
     originalUserAgent = Object.getOwnPropertyDescriptor(navigator, 'userAgent');
     originalVendor = Object.getOwnPropertyDescriptor(navigator, 'vendor');
     originalPlatform = Object.getOwnPropertyDescriptor(navigator, 'platform');

--- a/packages/quill/test/unit/core/utils/browser.spec.ts
+++ b/packages/quill/test/unit/core/utils/browser.spec.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isSafariOrWebKit, _clearBrowserDetectionCache } from '../../../../src/core/utils/browser.js';
+
+describe('Browser Detection', () => {
+  let originalUserAgent: PropertyDescriptor | undefined;
+  let originalVendor: PropertyDescriptor | undefined;
+  let originalPlatform: PropertyDescriptor | undefined;
+  let originalMaxTouchPoints: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    // Clear the cache before each test
+    _clearBrowserDetectionCache();
+    
+    originalUserAgent = Object.getOwnPropertyDescriptor(navigator, 'userAgent');
+    originalVendor = Object.getOwnPropertyDescriptor(navigator, 'vendor');
+    originalPlatform = Object.getOwnPropertyDescriptor(navigator, 'platform');
+    originalMaxTouchPoints = Object.getOwnPropertyDescriptor(
+      navigator,
+      'maxTouchPoints',
+    );
+  });
+
+  afterEach(() => {
+    if (originalUserAgent) {
+      Object.defineProperty(navigator, 'userAgent', originalUserAgent);
+    }
+    if (originalVendor) {
+      Object.defineProperty(navigator, 'vendor', originalVendor);
+    }
+    if (originalPlatform) {
+      Object.defineProperty(navigator, 'platform', originalPlatform);
+    }
+    if (originalMaxTouchPoints) {
+      Object.defineProperty(
+        navigator,
+        'maxTouchPoints',
+        originalMaxTouchPoints,
+      );
+    }
+  });
+
+  const mockNavigator = (
+    userAgent: string,
+    vendor = '',
+    platform = 'MacIntel',
+    maxTouchPoints = 0,
+  ) => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: userAgent,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'vendor', {
+      value: vendor,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'platform', {
+      value: platform,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: maxTouchPoints,
+      writable: true,
+      configurable: true,
+    });
+  };
+
+  describe('isSafariOrWebKit', () => {
+    it('detects Safari on macOS', () => {
+      mockNavigator(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+        'Apple Computer, Inc.',
+      );
+      expect(isSafariOrWebKit()).toBe(true);
+    });
+
+    it('detects Safari on iOS', () => {
+      mockNavigator(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+        'Apple Computer, Inc.',
+        'iPhone',
+      );
+      expect(isSafariOrWebKit()).toBe(true);
+    });
+
+    it('detects Safari on iPad', () => {
+      mockNavigator(
+        'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+        'Apple Computer, Inc.',
+        'iPad',
+      );
+      expect(isSafariOrWebKit()).toBe(true);
+    });
+
+    it('detects iPad with desktop mode (iPadOS 13+)', () => {
+      mockNavigator(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+        'Apple Computer, Inc.',
+        'MacIntel',
+        5, // iPad has multiple touch points
+      );
+      expect(isSafariOrWebKit()).toBe(true);
+    });
+
+    it('does not detect Chrome on macOS', () => {
+      mockNavigator(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+        'Google Inc.',
+      );
+      expect(isSafariOrWebKit()).toBe(false);
+    });
+
+    it('does not detect Firefox', () => {
+      mockNavigator(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) Gecko/20100101 Firefox/119.0',
+        '',
+      );
+      expect(isSafariOrWebKit()).toBe(false);
+    });
+
+    it('does not detect Chrome on Android', () => {
+      mockNavigator(
+        'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36',
+        'Google Inc.',
+        'Linux armv8l',
+      );
+      expect(isSafariOrWebKit()).toBe(false);
+    });
+
+    it('returns consistent results when called multiple times', () => {
+      mockNavigator(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
+        'Apple Computer, Inc.',
+      );
+      const firstCall = isSafariOrWebKit();
+      mockNavigator(
+        'different user agent',
+        'different vendor',
+        'different platform',
+        1,
+      );
+      const secondCall = isSafariOrWebKit();
+      mockNavigator(
+        'another user agent',
+        'another vendor',
+        'another platform',
+        2,
+      );
+      const thirdCall = isSafariOrWebKit();
+
+      expect(firstCall).toBe(true);
+      expect(secondCall).toBe(true);
+      expect(thirdCall).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Samsung Keyboard with predictive text doesn't fire `compositionend` events when users blur the editor, causing the last word to be lost. This affects all Quill-based editors in Miro (Stickies, Shapes, Docs).

## 🔗 Related PRs
- **Client PR**: [Fix Samsung Keyboard text loss in widgets (Part 1/2)](https://github.com/miroapp-dev/client/pull/44415)
- **This is Part 2 of a 2-part fix that requires both client and Quill changes**

## Root Cause
Quill uses `queueMicrotask` to handle `compositionend` asynchronously to work around a Safari bug. When combined with Samsung Keyboard's missing events, this creates a race condition where the editor is destroyed before composition completes.

## Solution Overview
This fix requires changes in both repositories:
1. **Client (companion PR)**: Ensure proper blur timing to trigger pending composition events
2. **Quill (this PR)**: Make composition handling synchronous for non-Safari browsers

![image](https://github.com/user-attachments/assets/627136fd-ced0-4c73-883e-eea3506289eb)

## Changes in This PR

### Browser Detection (`src/core/utils/browser.ts`)
- Added utility to detect Safari/WebKit browsers
- Includes caching for performance (no impact on typing speed)
- Handles edge cases like iPad in desktop mode

### Composition Handler (`src/core/composition.ts`)
- Made `queueMicrotask` conditional - only for Safari/WebKit
- Other browsers now handle `compositionend` synchronously
- Preserves the Safari bug workaround while fixing Samsung issue

### Tests
- Added comprehensive browser detection tests
- All existing quill tests pass
- Performance validated with caching mechanism

![image](https://github.com/user-attachments/assets/5418f6e0-b154-4666-88ad-486cd7cbcbbe)

## Deployment Notes
- **Must be deployed before the Client PR**
- After merge, publish new version for client to consume

