### PR TITLE
MDOCS-3155 soft line break

### DIFF
--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -62,10 +62,11 @@ class Block extends BlockBlot {
     const text = lines.shift() as string;
     if (text.length > 0) {
       const softLines = text.split(softBreakRegex);
-      let i = index;
-      softLines.forEach((str) => {
-        if (i < this.length() - 1 || this.children.tail == null) {
-          const insertIndex = Math.min(i, this.length() - 1);
+      if (index < this.length() - 1 || this.children.tail == null) {
+        let i = index;
+        softLines.forEach((str) => {
+          const addedChars = i - index;
+          const insertIndex = Math.min(i, this.length() - 1 + addedChars);
           if (str === SOFT_BREAK_CHARACTER) {
             super.insertAt(
               insertIndex,
@@ -75,7 +76,10 @@ class Block extends BlockBlot {
           } else {
             super.insertAt(insertIndex, str);
           }
-        } else {
+          i += str.length;
+        });
+      } else {
+        softLines.forEach((str) => {
           const insertIndex = this.children.tail.length();
           if (str === SOFT_BREAK_CHARACTER) {
             this.children.tail.insertAt(
@@ -86,9 +90,8 @@ class Block extends BlockBlot {
           } else {
             this.children.tail.insertAt(insertIndex, str);
           }
-        }
-        i += str.length;
-      });
+        });
+      }
 
       this.cache = {};
     }

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -178,6 +178,16 @@ describe('Editor', () => {
         <p><strong>012<br class="soft-break">3</strong></p>`);
     });
 
+    test('insert soft line break near the end', () => {
+      const editor = createEditor('<p>0123</p>');
+      editor.insertText(3, `45${SOFT_BREAK_CHARACTER}67`);
+      expect(editor.getDelta()).toEqual(
+        new Delta().insert(`01245${SOFT_BREAK_CHARACTER}673`).insert('\n'),
+      );
+      expect(editor.scroll.domnode).toEqualHtml(`
+        <p>0245<br class="soft-break">673</p>`);
+    });
+
     test('append soft line break', () => {
       const editor = createEditor('<ol><li data-list="bullet">0123</li></ol>');
       editor.insertText(4, SOFT_BREAK_CHARACTER);


### PR DESCRIPTION
### Motivation
When pasting text with a soft break in it near the end of a line, the soft break would (1) not be inserted and (2) the orignal preceeding characters would replace the soft breaks. For example

**Document:**
0123
     ^ - insert at index 3
**Change Delta:**
 {insert: '45[SOFT_LINE_BREAK]67'}
**Outcome**
01245**3**67

### Investigation
The issue is in block.ts 
```
 softLines.forEach((str) => {
        if (i < this.length() - 1 || this.children.tail == null) {
```
After the first invocation of the loop, we should go into the first if statement but we don't because
```i < this.length() - 1```
doesn't take into account the fact we have modified the document

### Fix
1. Check the if statement first
2. update insertIndex calculation in the first if `Math.min(i, this.length() - 1 + addedChars);`