### PR TITLE
MDOCS-3304 add a script to start a dev environment

### DIFF
--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -80,6 +80,7 @@
     "lint:eslint": "eslint .",
     "lint:tsc": "tsc --noEmit --skipLibCheck",
     "start": "[[ -z \"$npm_package_config_ports_webpack\" ]] && webpack-dev-server || webpack-dev-server --port $npm_package_config_ports_webpack",
+    "dev": "webpack serve --config test/e2e/__dev_server__/webpack.config.cjs --mode development",
     "test": "run-s test:*",
     "test:unit": "vitest --config test/unit/vitest.config.ts",
     "test:fuzz": "vitest --config test/fuzz/vitest.config.ts",


### PR DESCRIPTION
### Motivation
We need a way to run a demo editor for debugging and testing changes we are making to the repo

### Proposed change
Just add a script to run the dev server webpack config. This is just a quick way to give us something we can work with right away