### PR TITLE
Fixes: remove deprecated event

### DIFF
--- a/packages/quill/src/blots/scroll.ts
+++ b/packages/quill/src/blots/scroll.ts
@@ -46,7 +46,6 @@ class Scroll extends ScrollBlot {
     super(registry, domNode);
     this.emitter = emitter;
     this.batch = false;
-    this.domNode.addEventListener('DOMNodeInserted', () => {});
     this.optimize();
     this.enable();
     this.domNode.addEventListener('dragstart', (e) => this.handleDragStart(e));


### PR DESCRIPTION
Remove a deprecated and useless event handler which was filling up the console with noise