### PR TITLE
Refactor: make lists more accessible to screen readers

### DIFF
--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -84,7 +84,7 @@
     "test": "run-s test:*",
     "test:unit": "vitest --config test/unit/vitest.config.ts",
     "test:fuzz": "vitest --config test/fuzz/vitest.config.ts",
-    "test:e2e": "NODE_OPTIONS='--no-experimental-strip-types' playwright test"
+    "test:e2e": "playwright test"
   },
   "keywords": [
     "quill",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.0.4-beta.29",
+  "version": "2.0.4-beta.31",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",
@@ -84,7 +84,7 @@
     "test": "run-s test:*",
     "test:unit": "vitest --config test/unit/vitest.config.ts",
     "test:fuzz": "vitest --config test/fuzz/vitest.config.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "NODE_OPTIONS='--no-experimental-strip-types' playwright test"
   },
   "keywords": [
     "quill",

--- a/packages/quill/src/formats/list.ts
+++ b/packages/quill/src/formats/list.ts
@@ -11,6 +11,12 @@ class ListItem extends Block {
   static create(value: string) {
     const node = super.create() as HTMLElement;
     node.setAttribute('data-list', value);
+    if (value === 'checked' || value === 'unchecked') {
+      node.setAttribute('role', 'checkbox');
+      node.setAttribute('aria-checked', value === 'checked' ? 'true' : 'false');
+    } else {
+      node.setAttribute('role', 'listitem');
+    }
     return node;
   }
 
@@ -27,6 +33,7 @@ class ListItem extends Block {
     const ui = domNode.ownerDocument.createElement('span');
     // though the UI decoration is within the contenteditable, it should not be selectable
     ui.style.userSelect = 'none';
+    ui.setAttribute('aria-hidden', 'true');
 
     const listEventHandler = (e: Event) => {
       if (!scroll.isEnabled()) return;
@@ -47,9 +54,54 @@ class ListItem extends Block {
   format(name: string, value: string) {
     if (name === this.statics.blotName && value) {
       this.domNode.setAttribute('data-list', value);
+      this.domNode.style.listStyleType = 'none';
+      if (value === 'checked' || value === 'unchecked') {
+        this.domNode.setAttribute('role', 'checkbox');
+        this.domNode.setAttribute(
+          'aria-checked',
+          value === 'checked' ? 'true' : 'false',
+        );
+      } else {
+        this.domNode.removeAttribute('role');
+        this.domNode.removeAttribute('aria-checked');
+        this.updateAriaLabel();
+      }
     } else {
       super.format(name, value);
     }
+  }
+
+  insertAt(index: number, value: string, def?: unknown) {
+    super.insertAt(index, value, def);
+    this.updateAriaLabel();
+  }
+
+  deleteAt(index: number, length: number) {
+    super.deleteAt(index, length);
+    this.updateAriaLabel();
+  }
+
+  update(mutations: MutationRecord[], context: Record<string, unknown>): void {
+    super.update(mutations, context);
+    this.updateAriaLabel();
+  }
+
+  private updateAriaLabel() {
+    const text = this.domNode?.textContent?.trim();
+    if (!text) return;
+    let prefix = '';
+    const listType = this.domNode?.getAttribute('data-list');
+    if (listType === 'ordered') {
+      const siblings = Array.from(
+        this.domNode.parentNode?.querySelectorAll('li[data-list="ordered"]') ??
+          [],
+      );
+      const index = siblings.indexOf(this.domNode) + 1;
+      prefix = `${index}. `;
+    } else if (listType === 'bullet') {
+      prefix = '• ';
+    }
+    this.domNode.setAttribute('aria-label', prefix + text);
   }
 }
 ListItem.blotName = 'list';

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -224,7 +224,7 @@ describe('Editor', () => {
           .insert('\n', { list: 'bullet' }),
       );
       expect(editor.scroll.domNode).toEqualHTML(`
-        <ol><li data-list="bullet">0123<br class="soft-break" /><br /></li></ol>`);
+        <ol><li aria-label="• 0123" role="listitem" data-list="bullet">0123<br class="soft-break" /><br /></li></ol>`);
     });
 
     test('append soft line break in format', () => {
@@ -565,8 +565,8 @@ describe('Editor', () => {
       );
       expect(editor.scroll.domNode).toEqualHTML(
         `<ol>
-          <li data-list="ordered">0</li>
-          <li data-list="ordered">
+          <li role="listitem" data-list="ordered">0</li>
+          <li aria-label="2. 1" data-list="ordered" role="listitem">
             1
             <br class="soft-break"/>
             <br />
@@ -589,7 +589,7 @@ describe('Editor', () => {
       );
       expect(editor.scroll.domNode).toEqualHTML(
         `<ol>
-          <li data-list="ordered">0<br class="soft-break">1</li>
+          <li aria-label="1. 01" role="listitem" data-list="ordered">0<br class="soft-break">1</li>
         </ol>`,
       );
     });

--- a/packages/quill/test/unit/formats/list.spec.ts
+++ b/packages/quill/test/unit/formats/list.spec.ts
@@ -34,7 +34,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <p>0123</p>
       <ol>
-        <li data-list="ordered">5678</li>
+        <li role="listitem" data-list="ordered">5678</li>
       </ol>
       <p>0123</p>
     `);
@@ -63,8 +63,8 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="checked">0123</li>
-        <li data-list="unchecked">5678</li>
+        <li aria-checked="true" role="checkbox" data-list="checked">0123</li>
+        <li aria-checked="false" role="checkbox" data-list="unchecked">5678</li>
       </ol>
       <p>0123</p>
     `);
@@ -109,7 +109,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <p>0123</p>
       <ol>
-        <li data-list="bullet">5678</li>
+        <li aria-label="• 5678" style="list-style-type: none;" data-list="bullet">5678</li>
       </ol>
       <p>0123</p>
     `);
@@ -131,7 +131,7 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="bullet">0123</li>
+        <li aria-label="• 0123" style="list-style-type: none;" data-list="bullet">0123</li>
       </ol>
     `);
   });
@@ -150,7 +150,7 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li class="ql-align-center" data-list="bullet">0123</li>
+        <li aria-label="• 0123" style="list-style-type: none;" class="ql-align-center" data-list="bullet">0123</li>
       </ol>
     `);
   });
@@ -178,7 +178,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
         <li data-list="ordered">0123</li>
-        <li data-list="ordered">5678</li>
+        <li role="listitem" data-list="ordered">5678</li>
         <li data-list="ordered">0123</li>
       </ol>
     `);
@@ -232,7 +232,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
         <li data-list="checked">0123</li>
-        <li data-list="checked">5678</li>
+        <li aria-checked="true" role="checkbox" data-list="checked">5678</li>
         <li data-list="checked">0123</li>
       </ol>
     `);
@@ -245,13 +245,13 @@ describe('List', () => {
     editor.insertText(0, 'Test');
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">Test</li>
+        <li aria-label="1. Test" data-list="ordered">Test</li>
       </ol>
     `);
     editor.deleteText(0, 4);
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered"><br /></li>
+        <li aria-label="1. Test" data-list="ordered"><br /></li>
       </ol>
     `);
   });
@@ -270,7 +270,7 @@ describe('List', () => {
     editor.deleteText(2, 5);
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">0178</li>
+        <li aria-label="2. 78" data-list="ordered">0178</li>
         <li data-list="ordered">0123</li>
       </ol>
     `);
@@ -295,7 +295,7 @@ describe('List', () => {
     editor.deleteText(2, 5);
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">0178</li>
+        <li aria-label="1. 78" data-list="ordered">0178</li>
       </ol>
     `);
   });
@@ -315,9 +315,9 @@ describe('List', () => {
     editor.formatLine(1, 10, { list: 'bullet' });
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="bullet">One</li>
-        <li class="ql-indent-1" data-list="bullet">Alpha</li>
-        <li data-list="bullet">Two</li>
+        <li aria-label="• One" data-list="bullet" style="list-style-type: none;">One</li>
+        <li class="ql-indent-1" aria-label="• Alpha" data-list="bullet" style="list-style-type: none;">Alpha</li>
+        <li aria-label="• Two" data-list="bullet" style="list-style-type: none;">Two</li>
       </ol>
     `);
   });
@@ -329,7 +329,7 @@ describe('List', () => {
     editor.formatLine(4, 1, { list: 'bullet' });
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li class="ql-align-center" data-list="bullet">Test</li>
+        <li class="ql-align-center" data-list="bullet" role="listitem">Test</li>
       </ol>
     `);
   });
@@ -345,7 +345,7 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">Te</li>
+        <li aria-label="1. Te" data-list="ordered">Te</li>
       </ol>
       <iframe allowfullscreen="true" class="ql-video" frameborder="0" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
       <ol>
@@ -366,7 +366,7 @@ describe('List', () => {
     expect(editor.scroll.domNode).toEqualHTML(`
       <iframe allowfullscreen="true" class="ql-video" frameborder="0" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
       <ol>
-        <li data-list="ordered">Test</li>
+        <li aria-label="1. Test" data-list="ordered">Test</li>
       </ol>
     `);
   });
@@ -382,7 +382,7 @@ describe('List', () => {
     );
     expect(editor.scroll.domNode).toEqualHTML(`
       <ol>
-        <li data-list="ordered">Test</li>
+        <li aria-label="1. Test" data-list="ordered">Test</li>
       </ol>
       <iframe allowfullscreen="true" class="ql-video" frameborder="0" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
       <ol>


### PR DESCRIPTION
- Bullet and ordered list items have aria-label attributes attached to simulate proper semantic HTML
- Fake .ql-ui decorations have aria-hidden="true" applied so that they are not read aloud as "image"
- Checklists have role="checkbox" aria-checked="true|false" applied

This is an improvement, but it is _not_ bulletproof. There are certain text transformations where the aria-label can get out of sync with the text.