### PR TITLE
MDOCS-4862 Fix Break.optimize() to be cursor-transparent

### DIFF
--- a/packages/quill/src/blots/break.ts
+++ b/packages/quill/src/blots/break.ts
@@ -1,5 +1,33 @@
 import { EmbedBlot, LeafBlot, ParentBlot } from 'parchment';
+import type { Blot } from 'parchment';
+import Cursor from './cursor.js';
 import SoftBreak from './soft-break.js';
+
+const isCursor = (blot: Blot | null | undefined): boolean =>
+  blot != null && blot.statics.blotName === Cursor.blotName;
+
+const findPrevContentLeaf = (start: Blot | null): Blot | null => {
+  let prev = start;
+  while (prev != null) {
+    if (isCursor(prev)) {
+      prev = prev.prev;
+      continue;
+    }
+    if (prev instanceof ParentBlot) {
+      const leaf = prev
+        .descendants(LeafBlot)
+        .filter((descendant) => !isCursor(descendant))
+        .at(-1);
+      if (leaf != null) {
+        return leaf;
+      }
+      prev = prev.prev;
+      continue;
+    }
+    return prev;
+  }
+  return null;
+};
 
 class Break extends EmbedBlot {
   static value() {
@@ -7,16 +35,17 @@ class Break extends EmbedBlot {
   }
 
   optimize(): void {
-    const thisIsLastBlotInParent = this.next == null;
+    let next: Blot | null = this.next;
+    while (isCursor(next)) {
+      next = next!.next;
+    }
+    const thisIsLastBlotInParent = next == null;
     const thisIsFirstBlotInParent = this.prev == null;
     const thisIsOnlyBlotInParent =
       thisIsLastBlotInParent && thisIsFirstBlotInParent;
-    const prevLeaf =
-      this.prev instanceof ParentBlot
-        ? this.prev.descendants(LeafBlot).at(-1)
-        : this.prev;
+    const prevLeaf = findPrevContentLeaf(this.prev);
     const prevLeafIsSoftBreak =
-      prevLeaf != null && prevLeaf.statics.blotName == SoftBreak.blotName;
+      prevLeaf != null && prevLeaf.statics.blotName === SoftBreak.blotName;
     const shouldRender =
       thisIsOnlyBlotInParent || (thisIsLastBlotInParent && prevLeafIsSoftBreak);
     if (!shouldRender) {

--- a/packages/quill/test/e2e/soft-break.spec.ts
+++ b/packages/quill/test/e2e/soft-break.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures/index.js';
+import { SHORTKEY } from './utils/index.js';
+
+const SOFT_BREAK = ' ';
+
+test.describe('soft break', () => {
+  test('formatting a collapsed selection on the trailing line after soft-breaks does not crash', async ({
+    page,
+    editorPage,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
+
+    await editorPage.open();
+    await editorPage.setContents([
+      { insert: `We Have:${SOFT_BREAK}`, attributes: { bold: true } },
+      { insert: `${SOFT_BREAK}\n` },
+    ]);
+
+    // Verify the soft-breaks are present in the DOM
+    const softBreaks = await page.locator('.soft-break').count();
+    expect(softBreaks).toBe(2);
+
+    // Place the caret at the end of the document (trailing empty line)
+    await page.evaluate(() => {
+      // @ts-expect-error
+      const quill = window.quill;
+      quill.setSelection(quill.getLength() - 1, 0, 'silent');
+    });
+
+    await page.keyboard.press(`${SHORTKEY}+b`);
+    await page.keyboard.type('x');
+
+    expect(
+      pageErrors.filter((e) => e.message.includes('optimize iterations')),
+    ).toEqual([]);
+    expect(await editorPage.getContents()).toEqual([
+      { insert: `We Have:${SOFT_BREAK}`, attributes: { bold: true } },
+      { insert: SOFT_BREAK },
+      { insert: 'x', attributes: { bold: true } },
+      { insert: '\n' },
+    ]);
+  });
+});

--- a/packages/quill/test/e2e/soft-break.spec.ts
+++ b/packages/quill/test/e2e/soft-break.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures/index.js';
 import { SHORTKEY } from './utils/index.js';
 
-const SOFT_BREAK = ' ';
+const SOFT_BREAK = '\u2028';
 
 test.describe('soft break', () => {
   test('formatting a collapsed selection on the trailing line after soft-breaks does not crash', async ({

--- a/packages/quill/test/unit/blots/break.spec.ts
+++ b/packages/quill/test/unit/blots/break.spec.ts
@@ -26,7 +26,8 @@ describe('Break', () => {
     selection.format('bold', true);
     selection.scroll.optimize();
 
-    const lastChild = selection.scroll.domNode.querySelector('p')?.lastElementChild;
+    const lastChild =
+      selection.scroll.domNode.querySelector('p')?.lastElementChild;
     expect(lastChild?.tagName).toBe('BR');
   });
 });

--- a/packages/quill/test/unit/blots/break.spec.ts
+++ b/packages/quill/test/unit/blots/break.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import Selection, { Range } from '../../../src/core/selection.js';
+import Bold from '../../../src/formats/bold.js';
+import { createRegistry, createScroll } from '../__helpers__/factory.js';
+
+const SANDWICH_HTML =
+  '<p><strong>We Have:<br class="soft-break"></strong><br class="soft-break"><br></p>';
+
+const createSelection = (html: string) => {
+  const scroll = createScroll(html, createRegistry([Bold]));
+  return new Selection(scroll, scroll.emitter);
+};
+
+describe('Break', () => {
+  test('collapsed-selection format at a soft-break/inline boundary does not oscillate', () => {
+    const selection = createSelection(SANDWICH_HTML);
+    // Caret on the trailing empty line, as when a user clicks into it.
+    selection.setRange(new Range(selection.scroll.length() - 1, 0));
+
+    expect(() => selection.format('bold', true)).not.toThrow();
+  });
+
+  test('trailing break after a soft-break still renders after formatting', () => {
+    const selection = createSelection(SANDWICH_HTML);
+    selection.setRange(new Range(selection.scroll.length() - 1, 0));
+    selection.format('bold', true);
+    selection.scroll.optimize();
+
+    const lastChild = selection.scroll.domNode.querySelector('p')?.lastElementChild;
+    expect(lastChild?.tagName).toBe('BR');
+  });
+});


### PR DESCRIPTION
- Ticket: [MDOCS-4862](https://miro.atlassian.net/browse/MDOCS-4862)
- Client version with this fix: https://github.com/miroapp-dev/client/pull/68486

Formatting after a SoftBreak boundary no longer triggers a Parchment optimizer loop. This protects Grid cell re-entry when persisted content is reopened and formatting is applied to a collapsed selection.

## Impact

- Formatting at an affected SoftBreak boundary no longer exhausts optimizer iterations.
- Reopening an affected Grid cell keeps subsequent input in the cell.

## Technical highlights

- **Cursor-transparent traversal.** `Break.optimize()` skips transient `Cursor` blots while evaluating its next sibling and previous content leaf.
- **Focused regressions.** `break.spec.ts` covers the persisted HTML boundary, while `soft-break.spec.ts` uses U+2028 to create real SoftBreak blots.

## Test coverage

`break.spec.ts` collapsed-selection formatting and trailing-break rendering; `soft-break.spec.ts` browser coverage; fuzz suite; client shadow Grid re-entry and all-bold comparison.

## Mitigation

- [x] **Rollback/Hotfix** - Revert this change; consumers retain their published Quill package until a replacement beta is released.

## Manual testing

1. Seed a cell with bold text, a SoftBreak, an unformatted SoftBreak, and a trailing empty line. **Expect:** All breaks remain visible.
2. Place the caret on the trailing empty line, apply bold, and type. **Expect:** Formatting succeeds without an optimizer error.
3. Exit and re-enter the persisted Grid cell. **Expect:** The editor remains active and input stays in the cell.
4. Repeat with both SoftBreaks in the bold run. **Expect:** The comparison cell remains editable.