### PR TITLE
MDOCS-4862 Add Miro Quill release guidance and beta.32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Archive npm package tarball
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Archive npm package tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: npm
           path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Miro Quill Fork
+
+This is Miro's public fork of Quill.
+
+## Before You Work
+
+- Read `.github/DEVELOPMENT.md` before setup, build, or test work.
+- Read `.github/CONTRIBUTING.md` before preparing a contribution or pull request.
+
+## Miro Beta Releases
+
+- Before changing a Miro beta version or publishing, read the internal [Quill Contribution guide](https://miro.atlassian.net/wiki/spaces/SD/pages/4285268031/Quill+Contribution+guide).
+- Commit beta version bumps in `packages/quill/package.json`; keep Artifactory configuration, credentials, and `.npmrc` changes local and uncommitted.
+- `.github/workflows/release.yml` packages releases for public npm and GitHub Releases. Do not use it to publish the Artifactory beta consumed by Miro client.
+- Before updating the client dependency, verify the beta is available in Artifactory and comply with the client's package age gate.
+- If the contribution guide is unavailable, ask a maintainer rather than infer a publication path.

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill",
-  "version": "2.0.4-beta.31",
+  "version": "2.0.4-beta.32",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://quilljs.com",


### PR DESCRIPTION
- Ticket: [MDOCS-4862](https://miro.atlassian.net/browse/MDOCS-4862)

This reuses the draft as the release-preparation PR for the Grid soft-break fix. It removes the unmerged public release-workflow change from the final diff, adds source-backed Miro release guidance, and prepares `quill@2.0.4-beta.32`.

## Summary

- Add root `AGENTS.md` that directs standard development work to repository docs and Miro beta releases to the internal Quill Contribution guide.
- Keep private Artifactory configuration, credentials, and `.npmrc` changes out of the public fork.
- Bump only `packages/quill/package.json` to `2.0.4-beta.32`; the final PR has no `.github/workflows/release.yml` diff.

## Validation

- `git diff --check origin/main...HEAD`
- Final diff contains only `AGENTS.md` and `packages/quill/package.json`.
- Artifactory reported `2.0.4-beta.31` as the current beta and did not contain `.32` before the bump.

## Follow-up after merge

1. From clean, updated `main`, follow the internal Quill Contribution guide to build and publish the committed beta directly to Artifactory.
2. Verify the built manifest and Artifactory availability, then wait for the client package-age gate before updating the client dependency.