### PR TITLE
replace quill-delta with @mirohq/rich-text-delta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3994,6 +3994,19 @@
         "react": ">=16"
       }
     },
+    "node_modules/@mirohq/rich-text-delta": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mirohq/rich-text-delta/-/rich-text-delta-0.1.0.tgz",
+      "integrity": "sha512-+fa1osspQa17g7y/jEYxuVryVH1n7ZKNOjtY8R6Ue6xFZy0BVthLWO5R8zBNw6IIM2eog94dBwokv3LXtycS6w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-toolkit": "^1.50.0",
+        "fast-diff": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.1.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.3.tgz",
@@ -9226,6 +9239,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
     "node_modules/es5-ext": {
       "version": "0.10.64",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -13243,20 +13267,10 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -15557,19 +15571,6 @@
     "node_modules/quill": {
       "resolved": "packages/quill",
       "link": true
-    },
-    "node_modules/quill-delta": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-      "dependencies": {
-        "fast-diff": "^1.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -19240,13 +19241,13 @@
       }
     },
     "packages/quill": {
-      "version": "2.0.4-beta.28",
+      "version": "2.0.4-beta.32",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@mirohq/rich-text-delta": "^0.1.0",
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
-        "parchment": "^3.0.0",
-        "quill-delta": "^5.1.0"
+        "parchment": "^3.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.9",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -7,10 +7,10 @@
   "main": "quill.js",
   "type": "module",
   "dependencies": {
+    "@mirohq/rich-text-delta": "^0.1.0",
     "eventemitter3": "^5.0.1",
     "lodash-es": "^4.17.21",
-    "parchment": "^3.0.0",
-    "quill-delta": "^5.1.0"
+    "parchment": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.9",

--- a/packages/quill/src/blots/block.ts
+++ b/packages/quill/src/blots/block.ts
@@ -6,7 +6,7 @@ import {
   Scope,
 } from 'parchment';
 import type { Blot, Parent } from 'parchment';
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Break from './break.js';
 import Inline from './inline.js';
 import TextBlot from './text.js';

--- a/packages/quill/src/blots/scroll.ts
+++ b/packages/quill/src/blots/scroll.ts
@@ -1,6 +1,6 @@
 import { ContainerBlot, LeafBlot, Scope, ScrollBlot } from 'parchment';
 import type { Blot, Parent, EmbedBlot, ParentBlot, Registry } from 'parchment';
-import Delta, { AttributeMap, Op } from 'quill-delta';
+import Delta, { AttributeMap, Op } from '@mirohq/rich-text-delta';
 import Emitter from '../core/emitter.js';
 import type { EmitterSource } from '../core/emitter.js';
 import Block, { BlockEmbed, bubbleFormats } from './block.js';

--- a/packages/quill/src/core.ts
+++ b/packages/quill/src/core.ts
@@ -21,7 +21,7 @@ import Clipboard from './modules/clipboard.js';
 import History from './modules/history.js';
 import Keyboard from './modules/keyboard.js';
 import Uploader from './modules/uploader.js';
-import Delta, { Op, OpIterator, AttributeMap } from 'quill-delta';
+import Delta, { Op, OpIterator, AttributeMap } from '@mirohq/rich-text-delta';
 import Input from './modules/input.js';
 import UINode from './modules/uiNode.js';
 

--- a/packages/quill/src/core/editor.ts
+++ b/packages/quill/src/core/editor.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, isEqual, merge } from 'lodash-es';
 import { LeafBlot, EmbedBlot, Scope, ParentBlot } from 'parchment';
 import type { Blot } from 'parchment';
-import Delta, { AttributeMap, Op } from 'quill-delta';
+import Delta, { AttributeMap, Op } from '@mirohq/rich-text-delta';
 import Block, { BlockEmbed, bubbleFormats } from '../blots/block.js';
 import Break from '../blots/break.js';
 import CursorBlot from '../blots/cursor.js';

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash-es';
 import * as Parchment from 'parchment';
-import type { Op } from 'quill-delta';
-import Delta from 'quill-delta';
+import type { Op } from '@mirohq/rich-text-delta';
+import Delta from '@mirohq/rich-text-delta';
 import type { BlockEmbed } from '../blots/block.js';
 import type Block from '../blots/block.js';
 import type Scroll from '../blots/scroll.js';

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -7,7 +7,7 @@ import {
   Scope,
   StyleAttributor,
 } from 'parchment';
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { BlockEmbed } from '../blots/block.js';
 import type { EmitterSource } from '../core/emitter.js';
 import logger from '../core/logger.js';

--- a/packages/quill/src/modules/history.ts
+++ b/packages/quill/src/modules/history.ts
@@ -1,5 +1,5 @@
 import { Scope } from 'parchment';
-import type Delta from 'quill-delta';
+import type Delta from '@mirohq/rich-text-delta';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type Scroll from '../blots/scroll.js';

--- a/packages/quill/src/modules/input.ts
+++ b/packages/quill/src/modules/input.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Module from '../core/module.js';
 import Quill from '../core/quill.js';
 import type { Range } from '../core/selection.js';

--- a/packages/quill/src/modules/keyboard.ts
+++ b/packages/quill/src/modules/keyboard.ts
@@ -1,5 +1,5 @@
 import { cloneDeep, isEqual } from 'lodash-es';
-import Delta, { AttributeMap } from 'quill-delta';
+import Delta, { AttributeMap } from '@mirohq/rich-text-delta';
 import { EmbedBlot, Scope, TextBlot } from 'parchment';
 import type { Blot, BlockBlot } from 'parchment';
 import Quill from '../core/quill.js';

--- a/packages/quill/src/modules/syntax.ts
+++ b/packages/quill/src/modules/syntax.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { ClassAttributor, Scope } from 'parchment';
 import type { Blot, ScrollBlot } from 'parchment';
 import Inline from '../blots/inline.js';

--- a/packages/quill/src/modules/table.ts
+++ b/packages/quill/src/modules/table.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Quill from '../core/quill.js';
 import Module from '../core/module.js';
 import {

--- a/packages/quill/src/modules/tableEmbed.ts
+++ b/packages/quill/src/modules/tableEmbed.ts
@@ -1,5 +1,5 @@
-import Delta, { OpIterator } from 'quill-delta';
-import type { Op, AttributeMap } from 'quill-delta';
+import Delta, { OpIterator } from '@mirohq/rich-text-delta';
+import type { Op, AttributeMap } from '@mirohq/rich-text-delta';
 import Module from '../core/module.js';
 
 export type CellData = {

--- a/packages/quill/src/modules/toolbar.ts
+++ b/packages/quill/src/modules/toolbar.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { EmbedBlot, Scope } from 'parchment';
 import Quill from '../core/quill.js';
 import logger from '../core/logger.js';

--- a/packages/quill/src/modules/uploader.ts
+++ b/packages/quill/src/modules/uploader.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import type Quill from '../core/quill.js';
 import Emitter from '../core/emitter.js';
 import Module from '../core/module.js';

--- a/packages/quill/test/fuzz/editor.spec.ts
+++ b/packages/quill/test/fuzz/editor.spec.ts
@@ -1,5 +1,5 @@
-import type { Op } from 'quill-delta';
-import Delta, { AttributeMap } from 'quill-delta';
+import type { Op } from '@mirohq/rich-text-delta';
+import Delta, { AttributeMap } from '@mirohq/rich-text-delta';
 import { choose, randomInt, runFuzz } from './__helpers__/utils.js';
 import { AlignClass } from '../../src/formats/align.js';
 import { FontClass } from '../../src/formats/font.js';

--- a/packages/quill/test/fuzz/tableEmbed.spec.ts
+++ b/packages/quill/test/fuzz/tableEmbed.spec.ts
@@ -1,5 +1,5 @@
-import type { AttributeMap } from 'quill-delta';
-import Delta from 'quill-delta';
+import type { AttributeMap } from '@mirohq/rich-text-delta';
+import Delta from '@mirohq/rich-text-delta';
 import TableEmbed from '../../src/modules/tableEmbed.js';
 import type {
   CellData,

--- a/packages/quill/test/unit/blots/scroll.spec.ts
+++ b/packages/quill/test/unit/blots/scroll.spec.ts
@@ -3,7 +3,7 @@ import Emitter from '../../../src/core/emitter.js';
 import Selection, { Range } from '../../../src/core/selection.js';
 import Cursor from '../../../src/blots/cursor.js';
 import Scroll from '../../../src/blots/scroll.js';
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { createRegistry } from '../__helpers__/factory.js';
 import { normalizeHTML, sleep } from '../__helpers__/utils.js';
 import Underline from '../../../src/formats/underline.js';

--- a/packages/quill/test/unit/core/editor.spec.ts
+++ b/packages/quill/test/unit/core/editor.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Editor from '../../../src/core/editor.js';
 import Block from '../../../src/blots/block.js';
 import { Range } from '../../../src/core/selection.js';

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -1,5 +1,5 @@
 import '../../../src/quill.js';
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { LeafBlot, Registry } from 'parchment';
 import { afterEach, beforeEach, describe, expect, test, vitest } from 'vitest';
 import type { MockedFunction } from 'vitest';

--- a/packages/quill/test/unit/formats/align.spec.ts
+++ b/packages/quill/test/unit/formats/align.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Editor from '../../../src/core/editor.js';
 import { describe, test, expect } from 'vitest';
 import {

--- a/packages/quill/test/unit/formats/code.spec.ts
+++ b/packages/quill/test/unit/formats/code.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/formats/color.spec.ts
+++ b/packages/quill/test/unit/formats/color.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/formats/header.spec.ts
+++ b/packages/quill/test/unit/formats/header.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/indent.spec.ts
+++ b/packages/quill/test/unit/formats/indent.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/link.spec.ts
+++ b/packages/quill/test/unit/formats/link.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/list.spec.ts
+++ b/packages/quill/test/unit/formats/list.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import {
   createScroll as baseCreateScroll,
   createRegistry,

--- a/packages/quill/test/unit/formats/table.spec.ts
+++ b/packages/quill/test/unit/formats/table.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Editor from '../../../src/core/editor.js';
 import {
   createScroll as baseCreateScroll,

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { describe, expect, test, vitest } from 'vitest';
 import Quill from '../../../src/core.js';
 import { Range } from '../../../src/core/selection.js';

--- a/packages/quill/test/unit/modules/history.spec.ts
+++ b/packages/quill/test/unit/modules/history.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { describe, expect, test, vitest } from 'vitest';
 import Quill from '../../../src/core.js';
 import { getLastChangeIndex } from '../../../src/modules/history.js';

--- a/packages/quill/test/unit/modules/syntax.spec.ts
+++ b/packages/quill/test/unit/modules/syntax.spec.ts
@@ -1,5 +1,5 @@
 import hljs from 'highlight.js';
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import Quill from '../../../src/core.js';
 import Bold from '../../../src/formats/bold.js';

--- a/packages/quill/test/unit/modules/table.spec.ts
+++ b/packages/quill/test/unit/modules/table.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import Quill from '../../../src/core.js';
 import { describe, expect, test } from 'vitest';
 import { createRegistry } from '../__helpers__/factory.js';

--- a/packages/quill/test/unit/modules/tableEmbed.spec.ts
+++ b/packages/quill/test/unit/modules/tableEmbed.spec.ts
@@ -1,4 +1,4 @@
-import Delta from 'quill-delta';
+import Delta from '@mirohq/rich-text-delta';
 import { tableHandler } from '../../../src/modules/tableEmbed.js';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 


### PR DESCRIPTION
This is our fork of quill-delta which adds support for nested object attributes.

For now, this is just a drop-in replacement. There should be no effective behaviour change for quill.

This could be used to build blots which use object attribute values, allowing those objects' nested keys to be composed/transformed for collaborative editing in such a way that allows collaboration on partial changes to those objects.

There is currently no out-of-the-box use-case for this, but a common use-cases where this is useful are in cases where multiple instances of the same attribute can be applied over the same text (for example, inline text comments).